### PR TITLE
update action setup-python version

### DIFF
--- a/.github/workflows/generate-api.yml
+++ b/.github/workflows/generate-api.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: |


### PR DESCRIPTION
Fixes the github actions warning:
[Generate API JSON and YML Files](https://github.com/cdisc-org/usdm_api/actions/runs/8252986128/job/22573792098)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.